### PR TITLE
Fix invalid `.Binaries` path

### DIFF
--- a/Lambda.Core/Lambda.Core.csproj
+++ b/Lambda.Core/Lambda.Core.csproj
@@ -80,7 +80,7 @@
     <ItemGroup>
       <Binaries Include="$(OutputPath)\Unitask.dll" />
       <Binaries Include="$(OutputPath)\Unitask.*.dll" />
-      <Binaries Include="./.Binaries/libraries/ScriptEngine.dll" />
+      <Binaries Include="../.Binaries/ScriptEngine.dll" />
 
       <FilesToCopyToScripts Include="$(OutputPath)\$(MSBuildProjectName).dll" />
       <FilesToCopyToScripts Include="$(OutputPath)\$(MSBuildProjectName).pdb" />


### PR DESCRIPTION
The invalid `Include` path prevented `ScriptEngine.dll` from being copied to the plugins directory of a clean install.
Should `<None Include=".\Configuration\*">` and `<None Include=".\.Binaries*">` lines be updated too?